### PR TITLE
feat: :sparkles: introduced new product page components to handle Images

### DIFF
--- a/components/ProductPageComponents/ProductImageGallery/ImageGalleryMaster.tsx
+++ b/components/ProductPageComponents/ProductImageGallery/ImageGalleryMaster.tsx
@@ -1,0 +1,15 @@
+import { ProductSlideshowImages } from '../../../interfaces/product-slideshow-images';
+import ImageGalleryWithLeftThumbnails from './ImageGalleryWithLeftThumbnails';
+import ImageGalleryWithRightThumbnails from './ImageGalleryWithRightThumbnails';
+import ImageGalleryWithBottomThumbnails from './ImageGalleryWithBottomThumbnails';
+const ImageGalleryMaster = ({ slideShowImages }: ProductSlideshowImages) => {
+  return (
+    <>
+      {/* <ImageGalleryWithLeftThumbnails slideShowImages={slideShowImages} /> */}
+      {/* <ImageGalleryWithRightThumbnails slideShowImages={slideShowImages} /> */}
+      {/* <ImageGalleryWithBottomThumbnails slideShowImages={slideShowImages} /> */}
+    </>
+  );
+};
+
+export default ImageGalleryMaster;

--- a/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithBottomThumbnails.tsx
+++ b/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithBottomThumbnails.tsx
@@ -1,0 +1,57 @@
+import ReactImageMagnify from 'react-image-magnify';
+import Image from 'next/image';
+import { CONSTANTS } from '../../../services/config/app-config';
+import { ProductSlideshowImages } from '../../../interfaces/product-slideshow-images';
+import imageStyle from '../../../styles/components/productImgMagnify.module.scss';
+import useImageGallery from '../../../hooks/ProductImageGalleryHandler/useImageGallery';
+
+const ImageGalleryWithBottomThumbnails = ({ slideShowImages }: ProductSlideshowImages) => {
+  const { enlargeImg, activeImgIndex, handleSelectedImage, generateSrcSet } = useImageGallery({ slideShowImages });
+
+  return (
+    <div className={imageStyle.product_img_container}>
+      <div className={imageStyle.img_container_column}>
+        {/* Main Image */}
+        <div className={imageStyle.product_img_bottom}>
+          <ReactImageMagnify
+            {...{
+              smallImage: {
+                alt: 'Product image',
+                isFluidWidth: true,
+                width: 400,
+                height: 400,
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet to provide multiple resolutions
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 10vw, 10vw `, // Define sizes for different screen widths
+              },
+              largeImage: {
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet for large image as well
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 30vw`,
+                width: 1200,
+                height: 1200,
+              },
+              // enlargedImageClassName: `${imageStyle.magnified_image}`,
+              enlargedImagePosition: 'beside', // Ensure the image appears beside the main image
+            }}
+          />
+        </div>
+
+        {/* Thumbnails */}
+        <div className={imageStyle.thumbnail_bottom}>
+          {slideShowImages.map((image: string, i: number) => (
+            <div
+              className={`${imageStyle.img_wrap} ${i === activeImgIndex ? `${imageStyle.active}` : ''}`}
+              key={i}
+              onClick={() => handleSelectedImage(image, i)}
+            >
+              <Image src={`${CONSTANTS.API_BASE_URL}/${image}`} alt={`Thumbnail image ${i + 1}`} width={100} height={100} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImageGalleryWithBottomThumbnails;

--- a/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithLeftThumbnails.tsx
+++ b/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithLeftThumbnails.tsx
@@ -1,0 +1,56 @@
+import ReactImageMagnify from 'react-image-magnify';
+import Image from 'next/image';
+import { CONSTANTS } from '../../../services/config/app-config';
+import { ProductSlideshowImages } from '../../../interfaces/product-slideshow-images';
+import imageStyle from '../../../styles/components/productImgMagnify.module.scss';
+import useImageGallery from '../../../hooks/ProductImageGalleryHandler/useImageGallery';
+
+const ImageGalleryWithLeftThumbnails = ({ slideShowImages }: ProductSlideshowImages) => {
+  const { enlargeImg, activeImgIndex, handleSelectedImage, generateSrcSet } = useImageGallery({ slideShowImages });
+
+  return (
+    <div className={imageStyle.product_img_container}>
+      <div className={imageStyle.img_container}>
+        {/* Thumbnails */}
+        <div className={imageStyle.thumbnail_left}>
+          {slideShowImages.map((image: string, i: number) => (
+            <div
+              className={`${imageStyle.img_wrap} ${i === activeImgIndex ? `${imageStyle.active}` : ''}`}
+              key={i}
+              onClick={() => handleSelectedImage(image, i)}
+            >
+              <Image src={`${CONSTANTS.API_BASE_URL}/${image}`} alt={`Thumbnail image ${i + 1}`} width={100} height={100} />
+            </div>
+          ))}
+        </div>
+
+        {/* Magnified Image */}
+        <div className={imageStyle.product_img}>
+          <ReactImageMagnify
+            {...{
+              smallImage: {
+                alt: 'Product image',
+                isFluidWidth: true,
+                width: 600,
+                height: 600,
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet to provide multiple resolutions
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 90vw, 90vw`, // Define sizes for different screen widths
+              },
+              largeImage: {
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet for large image as well
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 30vw`,
+                width: 1200,
+                height: 1200,
+              },
+              enlargedImageClassName: `${imageStyle.magnified_image}`,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImageGalleryWithLeftThumbnails;

--- a/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithRightThumbnails.tsx
+++ b/components/ProductPageComponents/ProductImageGallery/ImageGalleryWithRightThumbnails.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import ReactImageMagnify from 'react-image-magnify';
+import Image from 'next/image';
+import { CONSTANTS } from '../../../services/config/app-config';
+import { ProductSlideshowImages } from '../../../interfaces/product-slideshow-images';
+import imageStyle from '../../../styles/components/productImgMagnify.module.scss';
+import useImageGallery from '../../../hooks/ProductImageGalleryHandler/useImageGallery';
+const ImageGalleryWithRightThumbnails = ({ slideShowImages }: ProductSlideshowImages) => {
+  const { enlargeImg, activeImgIndex, handleSelectedImage, generateSrcSet } = useImageGallery({ slideShowImages });
+
+  return (
+    <div className={imageStyle.product_img_container}>
+      <div className={imageStyle.img_container}>
+        {/* Thumbnails */}
+        <div className={imageStyle.thumbnail_right}>
+          {slideShowImages.map((image: string, i: number) => (
+            <div
+              className={`${imageStyle.img_wrap} ${i === activeImgIndex ? `${imageStyle.active}` : ''}`}
+              key={i}
+              onClick={() => handleSelectedImage(image, i)}
+            >
+              <Image src={`${CONSTANTS.API_BASE_URL}/${image}`} alt={`Thumbnail image ${i + 1}`} width={100} height={100} />
+            </div>
+          ))}
+        </div>
+
+        {/* Magnified Image */}
+        <div className={imageStyle.product_img}>
+          <ReactImageMagnify
+            {...{
+              smallImage: {
+                alt: 'Product image',
+                isFluidWidth: true,
+                width: 600,
+                height: 600,
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet to provide multiple resolutions
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 90vw, 90vw`, // Define sizes for different screen widths
+              },
+              largeImage: {
+                src: `${CONSTANTS.API_BASE_URL}/${enlargeImg}`,
+                srcSet: generateSrcSet(enlargeImg), // Use srcSet for large image as well
+                sizes: `(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 30vw`,
+                width: 1200,
+                height: 1200,
+              },
+              enlargedImageClassName: `${imageStyle.magnified_image}`,
+              enlargedImagePosition: 'beside', // Ensure the image appears beside the main image
+              enlargedImageContainerClassName: `${imageStyle.magnified_image_right}`,
+              // enlargedImageContainerDimensions: { width: '100%', height: '100%' },
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImageGalleryWithRightThumbnails;

--- a/styles/components/productImgMagnify.module.scss
+++ b/styles/components/productImgMagnify.module.scss
@@ -1,0 +1,126 @@
+.product_img_container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.img_container {
+  display: flex;
+  height: 70vh;
+  gap: 10px;
+}
+.thumbnail_left {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.img_container_column {
+  display: flex;
+  flex-direction: column; /* Change flex direction to column to stack image and thumbnails */
+  height: 95vh; /* Increase the container's height to make space for the thumbnails below */
+  gap: 20px; /* Add space between image and thumbnails */
+}
+.thumbnail_bottom {
+  display: flex;
+  // margin-top: -90px;
+  z-index: 3;
+  margin-bottom: 40px;
+  gap: 10px;
+}
+
+.thumbnail_right {
+  display: flex; /* Align thumbnails */
+  flex-direction: column; /* Stack thumbnails vertically */
+  gap: 10px; /* Add space between thumbnails */
+  margin-left: 20px; /* Add space between the main image and thumbnails */
+  margin-right: 0; /* Remove any default right margin */
+  order: 2; /* Ensure this comes after the main image in flex order */
+}
+
+.img_wrap {
+  // max-width: 80px !important;
+  // max-height: 80px !important;
+  max-width: 100px !important; /* Increase thumbnail size */
+  max-height: 100px !important; /* Increase thumbnail size */
+  border: 1px solid #eee;
+  cursor: pointer;
+}
+.img_wrap img {
+  // max-width: 70px !important;
+  // max-height: 70px !important;
+  max-width: 92px !important; /* Thumbnail inner image size */
+  max-height: 92px !important; /* Thumbnail inner image size */
+  object-fit: contain;
+}
+.img_container img {
+  width: 600px;
+  width: 800px; /* Larger product image */
+  height: 100%;
+  object-fit: contain;
+}
+.active {
+  border: 3px solid #e77600 !important;
+}
+
+.magnified_image {
+  min-width: 100% !important;
+  min-height: 100% !important;
+  object-fit: contain !important;
+}
+.magnified_image_right {
+  margin-left: 150px !important;
+}
+
+.product_img_bottom {
+  width: 100%; /* Allow product image to take full width */
+  max-width: 80%;
+  height: 80%;
+}
+
+/* Media Query for Mobile View */
+@media (max-width: 768px) {
+  .product_img_container {
+    flex-direction: column; /* Stack product image and thumbnails vertically */
+    align-items: center;
+  }
+
+  .img_container {
+    flex-direction: column; /* Stack the images vertically */
+    align-items: center;
+  }
+  .thumbnail_left {
+    width: 100%; /* Make the thumbnail container take full width */
+    flex-direction: row; /* Arrange thumbnails in a row on mobile */
+    justify-content: space-around;
+    gap: 5px;
+    overflow-x: scroll; /* Allow scrolling for thumbnails */
+  }
+  .thumbnail_right {
+    width: 100%; /* Make the thumbnail container take full width */
+    flex-direction: row; /* Arrange thumbnails in a row on mobile */
+    justify-content: space-around;
+    gap: 5px;
+    overflow-x: scroll; /* Allow scrolling for thumbnails */
+  }
+
+  .img_wrap {
+    max-width: 100px; /* Adjust the size of thumbnails */
+    max-height: 100px;
+  }
+
+  .product_img {
+    width: 100%; /* Allow product image to take full width */
+    max-width: 100%;
+  }
+
+  .magnified_image {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+  }
+
+  .magnified_image_right {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+  }
+}


### PR DESCRIPTION
# Description

This PR introduces two new components for displaying image galleries with different thumbnail layouts. The galleries enhance the user experience by allowing users to preview and magnify product images. Below are the key features:

* Bottom Thumbnails Layout: Displays thumbnails horizontally below the main image. Users can click on a thumbnail to view and magnify the corresponding image.
* Left Thumbnails Layout: Displays thumbnails vertically to the left of the main image. It provides an alternate design that can adapt to different page layouts.
* Right Thumbnails Layout: Displays thumbnails vertically to the right of the main image. It provides an alternate design that can adapt to different page layouts.

The magnification of product images is handled seamlessly using the react-image-magnify library.

# Type of Change
- [x] New feature (non-breaking change which adds functionality)

# Dependencies
- [x] Added react-image-magnify to manage image magnification efficiently.

# Screenshots
![img-gallery-bottom-thumbnails](https://github.com/user-attachments/assets/56ac4ce7-f8a8-43ec-ab86-906f90228625)
![img-gallery-left-thumbnails](https://github.com/user-attachments/assets/c0a37096-fb29-4616-92c3-3bfc271deb60)
![img-gallery-right-thumbnails](https://github.com/user-attachments/assets/5d17c245-e7b5-4c2a-9a03-98501fb748cf)
